### PR TITLE
Revert "Fix formatting issues"

### DIFF
--- a/conduct.md
+++ b/conduct.md
@@ -89,10 +89,10 @@ Decisions are the process by which team members collectively discuss their proje
 
 #### Acceptable Conduct
 
-- Students should finalize decisions when the team reaches a majority vote.
-- Students should consider and discuss all possible ideas of each student before moving forward.
-- Students should document how they reached the final decisions.
-- Students should make space for quieter voices on the team to speak.
+- Teams should finalize decisions when the team reaches a majority vote.
+- Teams should consider and discuss all possible ideas of each student before moving forward.
+- Teams should document how they reached the final decisions.
+- Teams should make space for quieter voices on the team to speak.
 - Students should not take final decisions personally.
 
 #### Unacceptable Conduct


### PR DESCRIPTION
Reverts Jacob-Allebach/code-of-conduct#16

Hey Jacob, thanks for your suggestion. However, the TL, and the professor and I have already talked about this in the pull request and I wonder if you have reviewed my pull request. There was this conversation in there:

> Thanks for the review. I thought about using "students should" as well, but in the code of conduct formatting issue tracker, we said:

> but if needed use the terms "team members" or "teams" to describe groups of students. I think this is probably the best solution for consistency purposes. Let me know if you disagree!

> So, I thought it was more appropriate to use" team members" here because decisions are made between team members rather than all the students in the class.

Let me know if you have any issues with it!